### PR TITLE
Apply new button design on sell/buy button in offer modal

### DIFF
--- a/frontend/imports/ui/client/widgets/offermodal.html
+++ b/frontend/imports/ui/client/widgets/offermodal.html
@@ -116,8 +116,8 @@
         <div class="modal-footer">
           {{#if or (and hasBalance hasAllowance) (not hasBalance)}}
             {{#if offer}}
-              <button type="button" class="btn btn-submit-order dex-btn-default {{offerType}} btn-placement-right" data-dismiss="modal" {{b "enable: canBuy, click: buy"}}>
-                {{#if equals offer.type 'bid'}}SELL{{else}}BUY ASD{{/if}} {{baseCurrency}}
+              <button type="button" class="btn dex-btn-default {{#if equals offer.type 'bid'}}sell{{else}}buy{{/if}} btn-placement-right" data-dismiss="modal" {{b "enable: canBuy, click: buy"}}>
+                {{#if equals offer.type 'bid'}}SELL{{else}}BUY{{/if}} {{baseCurrency}}
               </button>
             {{/if}}
           {{else}}


### PR DESCRIPTION
Broken: 
![broken](https://cloud.githubusercontent.com/assets/23715025/26605259/a3a62a0c-458d-11e7-8aa0-55fa7ac98b19.png)

Fixed: 
![fixed](https://cloud.githubusercontent.com/assets/23715025/26605265/a8d7b770-458d-11e7-8056-07420d6a920d.png)

The reason why it wasn't applied out of the box is because there is a variable (offerType) which evaluates to empty string. This variable is part of a shared state between different templates. The problem dates from the past. I went  to commits 1 month ago and it was still there.

This is a quick fix in order no to waste time in fixing it since we might be investing our time in new design.

@gbalabasquer @pimato @nanexcool 