### PR TITLE
Volume and Total in the order details are as in order not according to the balance of the user. (this is a revert of functionality #313)

### DIFF
--- a/frontend/imports/ui/client/widgets/offermodal.js
+++ b/frontend/imports/ui/client/widgets/offermodal.js
@@ -37,10 +37,10 @@ Template.offermodal.viewmodel({
         const buyHowMuch = web3Obj.fromWei(new BigNumber(offer.buyHowMuch)).toString(10);
         const baseCurrency = Session.get('baseCurrency');
         if (baseCurrency === offer.buyWhichToken) {
-          this.fillOrderPartiallyOrFully(this.volume, this.baseAvailable(), web3Obj.toWei(buyHowMuch));
+          this.volume(buyHowMuch);
           this.calcTotal();
         } else {
-          this.fillOrderPartiallyOrFully(this.total, this.quoteAvailable(), web3Obj.toWei(buyHowMuch));
+          this.total(buyHowMuch);
           this.calcVolume();
         }
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23715025/30267721-c18d15f6-96e3-11e7-93fd-a4075ea5b499.png)

Revert of #313 (requested by @pimato )

@gbalabasquer - code review