### PR TITLE
Revert global loading indicatgor for market widget

### DIFF
--- a/frontend/imports/ui/client/widgets/markets.html
+++ b/frontend/imports/ui/client/widgets/markets.html
@@ -19,7 +19,6 @@
         </tr>
         </thead>
         <tbody class="{{#if showScroll}}tbody-scrolling{{else}}tbody-not-scrolling{{/if}}">
-        {{#unless loadingTradeHistory}}
           {{#each tradingPairs}}
             {{#if or showAll this.isVisible }}
               <tr class="clickable {{ selected(this) }}" {{b "click: select(this)"}}>
@@ -67,9 +66,6 @@
             </tr>
           {{/unless}}
           <!--{{sort}}-->
-        {{else}}
-          <div class="loading-market-history">{{{loadingIcon}}} Loading trading history...</div>
-        {{/unless}}
         </tbody>
         <tfoot>
 


### PR DESCRIPTION
Revert this:

![image](https://user-images.githubusercontent.com/23715025/30269414-0370e862-96e9-11e7-98e7-91c4ce79cb18.png)

to this: 

![image](https://user-images.githubusercontent.com/23715025/30269427-0cac804e-96e9-11e7-836a-6b60f6c21859.png)

@pimato @gbalabasquer 